### PR TITLE
APIサーバの基本URLを.envで設定できるようにしました

### DIFF
--- a/frontend/ShareEngine/.env-sample
+++ b/frontend/ShareEngine/.env-sample
@@ -1,0 +1,11 @@
+#
+# APIサーバのベースURL
+#
+
+# ローカルのAndroid Studio用
+# API_BASE=http://10.0.2.2:8000/api/v1
+
+# ローカルのXCode Simulator用
+# API_BASE=http://localhost:8000/api/v1
+
+API_BASE=http://localhost:8000/api/v1

--- a/frontend/ShareEngine/.env.production
+++ b/frontend/ShareEngine/.env.production
@@ -1,0 +1,5 @@
+#
+# APIサーバのベースURL
+#
+
+API_BASE=https://share-engine.click/api/v1

--- a/frontend/ShareEngine/.gitignore
+++ b/frontend/ShareEngine/.gitignore
@@ -64,3 +64,5 @@ yarn-error.log
 
 # testing
 /coverage
+
+.env

--- a/frontend/ShareEngine/android/app/build.gradle
+++ b/frontend/ShareEngine/android/app/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:flipper-integration")
+    implementation project(':react-native-config')
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
@@ -117,3 +118,4 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"

--- a/frontend/ShareEngine/android/settings.gradle
+++ b/frontend/ShareEngine/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'ShareEngine'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+include ':react-native-config'
+project(':react-native-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config/android')
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/frontend/ShareEngine/ios/Podfile.lock
+++ b/frontend/ShareEngine/ios/Podfile.lock
@@ -944,6 +944,10 @@ PODS:
   - React-Mapbuffer (0.73.4):
     - glog
     - React-debug
+  - react-native-config (1.5.1):
+    - react-native-config/App (= 1.5.1)
+  - react-native-config/App (1.5.1):
+    - React-Core
   - react-native-image-picker (7.1.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1188,6 +1192,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
@@ -1288,6 +1293,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   React-Mapbuffer:
     :path: "../node_modules/react-native/ReactCommon"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
   react-native-safe-area-context:
@@ -1348,7 +1355,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
-  FBReactNativeSpec: d0086a479be91c44ce4687a962956a352d2dc697
+  FBReactNativeSpec: 291ffa628409943e6388fbb1b447c2aeb26cf10e
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1383,6 +1390,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 9ac353eccf6ab54d1e0a33862ba91221d1e88460
   React-logger: 0a57b68dd2aec7ff738195f081f0520724b35dab
   React-Mapbuffer: 63913773ed7f96b814a2521e13e6d010282096ad
+  react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-image-picker: 6c51359eca7a7df9f07e297218c25696eb9da976
   react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
@@ -1400,13 +1408,13 @@ SPEC CHECKSUMS:
   React-RCTText: f0176f5f5952f9a4a2c7354f5ae71f7c420aaf34
   React-RCTVibration: 8160223c6eda5b187079fec204f80eca8b8f3177
   React-rendererdebug: ed286b4da8648c27d6ed3ae1410d4b21ba890d5a
-  React-rncore: 43f133b89ac10c4b6ab43702a541dee1c292a3bf
+  React-rncore: 318002790813e9185ae2a8eecfdb3afef0f29d9e
   React-runtimeexecutor: e6ab6bb083dbdbdd489cff426ed0bce0652e6edf
   React-runtimescheduler: ed48e5faac6751e66ee1261c4bd01643b436f112
   React-utils: 6e5ad394416482ae21831050928ae27348f83487
   ReactCommon: 840a955d37b7f3358554d819446bffcf624b2522
   RNGestureHandler: deda62b8339496ba721a45e0f3e2d7a319932cee
-  RNReanimated: 7d6d32f238f914f13d9d6fb45c0aef557f7f901e
+  RNReanimated: 2688e72bacc302a956419784bf0f737cad60c75d
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   RNSecureStorage: d7de7dd7321ae113a6f7dad1747a4992a20b4955
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/frontend/ShareEngine/package-lock.json
+++ b/frontend/ShareEngine/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native-stack": "^6.9.18",
         "react": "18.2.0",
         "react-native": "^0.73.4",
+        "react-native-config": "^1.5.1",
         "react-native-gesture-handler": "^2.15.0",
         "react-native-image-picker": "^7.1.0",
         "react-native-reanimated": "^3.7.0",
@@ -25,8 +26,10 @@
         "@babel/core": "^7.20.0",
         "@babel/preset-env": "^7.20.0",
         "@babel/runtime": "^7.20.0",
+        "@react-native-community/cli-platform-android": "^12.3.5",
         "@react-native/babel-preset": "0.73.21",
         "@react-native/eslint-config": "0.73.2",
+        "@react-native/gradle-plugin": "^0.73.4",
         "@react-native/metro-config": "0.73.5",
         "@react-native/typescript-config": "0.73.1",
         "@types/react": "^18.2.6",
@@ -3232,6 +3235,19 @@
         "yaml": "^2.2.1"
       }
     },
+    "node_modules/@react-native-community/cli-doctor/node_modules/@react-native-community/cli-platform-android": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.2.tgz",
+      "integrity": "sha512-MZ5nO8yi/N+Fj2i9BJcJ9C/ez+9/Ir7lQt49DWRo9YDmzye66mYLr/P2l/qxsixllbbDi7BXrlLpxaEhMrDopg==",
+      "dependencies": {
+        "@react-native-community/cli-tools": "12.3.2",
+        "chalk": "^4.1.2",
+        "execa": "^5.0.0",
+        "fast-xml-parser": "^4.2.4",
+        "glob": "^7.1.3",
+        "logkitty": "^0.7.1"
+      }
+    },
     "node_modules/@react-native-community/cli-doctor/node_modules/ansi-regex": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -3357,6 +3373,19 @@
         "ip": "^1.1.5"
       }
     },
+    "node_modules/@react-native-community/cli-hermes/node_modules/@react-native-community/cli-platform-android": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.2.tgz",
+      "integrity": "sha512-MZ5nO8yi/N+Fj2i9BJcJ9C/ez+9/Ir7lQt49DWRo9YDmzye66mYLr/P2l/qxsixllbbDi7BXrlLpxaEhMrDopg==",
+      "dependencies": {
+        "@react-native-community/cli-tools": "12.3.2",
+        "chalk": "^4.1.2",
+        "execa": "^5.0.0",
+        "fast-xml-parser": "^4.2.4",
+        "glob": "^7.1.3",
+        "logkitty": "^0.7.1"
+      }
+    },
     "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3422,11 +3451,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.2.tgz",
-      "integrity": "sha512-MZ5nO8yi/N+Fj2i9BJcJ9C/ez+9/Ir7lQt49DWRo9YDmzye66mYLr/P2l/qxsixllbbDi7BXrlLpxaEhMrDopg==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.5.tgz",
+      "integrity": "sha512-vkoEoP2qKwdf8jxkrL2b35k+9eTNRFO9J6QhkVJS8AgSDcwLDvSEUCHoDBNCHaohFHP1wDWixYG4QwDOx+GfFw==",
+      "dev": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "12.3.2",
+        "@react-native-community/cli-tools": "12.3.5",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-xml-parser": "^4.2.4",
@@ -3434,10 +3464,29 @@
         "logkitty": "^0.7.1"
       }
     },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/@react-native-community/cli-tools": {
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-12.3.5.tgz",
+      "integrity": "sha512-Q7LKvu9pt3dR8XngcMfqo42XVEKzOad+4vaqRkpBUkKkZwXv41UFDxeK16NmUP87rDpHQNBbgCjJcpSq57hWsw==",
+      "dev": true,
+      "dependencies": {
+        "appdirsjs": "^1.2.4",
+        "chalk": "^4.1.2",
+        "find-up": "^5.0.0",
+        "mime": "^2.4.1",
+        "node-fetch": "^2.6.0",
+        "open": "^6.2.0",
+        "ora": "^5.4.1",
+        "semver": "^7.5.2",
+        "shell-quote": "^1.7.3",
+        "sudo-prompt": "^9.0.0"
+      }
+    },
     "node_modules/@react-native-community/cli-platform-android/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3452,6 +3501,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3467,6 +3517,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3477,26 +3528,108 @@
     "node_modules/@react-native-community/cli-platform-android/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@react-native-community/cli-platform-ios": {
       "version": "12.3.2",
@@ -12029,6 +12162,19 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "peerDependencies": {
+        "react-native-windows": ">=0.61"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.15.0.tgz",
@@ -12121,6 +12267,19 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native-community/cli-platform-android": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.2.tgz",
+      "integrity": "sha512-MZ5nO8yi/N+Fj2i9BJcJ9C/ez+9/Ir7lQt49DWRo9YDmzye66mYLr/P2l/qxsixllbbDi7BXrlLpxaEhMrDopg==",
+      "dependencies": {
+        "@react-native-community/cli-tools": "12.3.2",
+        "chalk": "^4.1.2",
+        "execa": "^5.0.0",
+        "fast-xml-parser": "^4.2.4",
+        "glob": "^7.1.3",
+        "logkitty": "^0.7.1"
       }
     },
     "node_modules/react-native/node_modules/@types/yargs": {

--- a/frontend/ShareEngine/package.json
+++ b/frontend/ShareEngine/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^6.9.18",
     "react": "18.2.0",
     "react-native": "^0.73.4",
+    "react-native-config": "^1.5.1",
     "react-native-gesture-handler": "^2.15.0",
     "react-native-image-picker": "^7.1.0",
     "react-native-reanimated": "^3.7.0",

--- a/frontend/ShareEngine/src/Utils.tsx
+++ b/frontend/ShareEngine/src/Utils.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
+import Config from "react-native-config";
 import RNSecureStorage, {ACCESSIBLE} from 'rn-secure-storage';
+
+const apiBase = Config.API_BASE;
 
 export const handleLogout = async (navigation: any) => {
     console.log('Logging out');
@@ -19,7 +22,7 @@ export const handleLogout = async (navigation: any) => {
 export const getUserID = async () => {
     if (await existsSecureItem('token')) {
         const token = await getSecureItem('token');
-        const response = await fetch('https://share-engine.click/api/v1/me', {
+        const response = await fetch(`${apiBase}/me`, {
             method: 'GET',
             headers: {
                 Authorization: 'Bearer ' + token,
@@ -105,8 +108,8 @@ export const fetchUsersRequest = async () => {
         console.error('Error fetching items:', error);
     }
 }
-const usersUrl = 'https://share-engine.click/api/v1/users'
-const itemsUrl = 'https://share-engine.click/api/v1/items/'
+const usersUrl = `${apiBase}/users`
+const itemsUrl = `${apiBase}/items/`
 // const itemsUrl = 'http://34.71.228.117/api/v1/items/'
 // const itemDetailsUrl = 'http://localhost:8000/api/v1/items/'
 
@@ -172,7 +175,7 @@ export const loginRequest = async (username: string, password: string) => {
         "password": password,
     };
     const method = 'POST';
-    const response = await fetch('https://share-engine.click/api/v1/login', {
+    const response = await fetch(`${apiBase}/login`, {
         method: method,
         headers: {
             "Content-Type": "application/json",
@@ -189,7 +192,7 @@ export const registerRequest = async (username: string, password: string) => {
         "password": password,
     };
     const method = 'POST';
-    const response = await fetch("https://share-engine.click/api/v1/users/", {
+    const response = await fetch(`${apiBase}/users/`, {
         method: method,
         headers: {
             "Content-Type": "application/json",

--- a/frontend/ShareEngine/src/definitions/react-native-config.d.ts
+++ b/frontend/ShareEngine/src/definitions/react-native-config.d.ts
@@ -1,0 +1,8 @@
+declare module 'react-native-config' {
+  export interface NativeConfig {
+    API_BASE?: string;
+  }
+
+  export const Config: NativeConfig;
+  export default Config;
+}


### PR DESCRIPTION
## このPRは何か

APIサーバの基本URLを.envで設定できるようにしました

## 動作確認

ライブラリを追加したのでインストール
```
npm i
```

.env-sampleをコピーして`.env`ファイルを作る

```
cp frontend/ShareEngine/.env-sample frontend/ShareEngine/.env
```

```env
#
# APIサーバのベースURL
#

# ローカルのAndroid Studio用
# API_BASE=http://10.0.2.2:8000/api/v1

# ローカルのXCode Simulator用
# API_BASE=http://localhost:8000/api/v1

API_BASE=http://localhost:8000/api/v1
```

_AndroidのエミュレータからホストPCを見るにはIPアドレス `10.0.2.2` になるみたいです_
_iOSのエミュレータはlocalhostで見れる_

ローカルDockerでAPサーバを起動する

```
docker compose -f backend/docker-compose.yml up
```

ビルドしてAndroid / iOSのエミュレータを起動する

```
cd frontend/ShareEngine
npm run start
```

`i` を押したり `a` を押したりしてアプリを起動する

APIリクエストが、指定したURLに送信されていたら成功