### PR TITLE
OpenAPIのスキーマJSONをコマンドラインから出力できるようになったら嬉しいなという気持ち

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Share Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # Qiita Hackathonで作ったアプリ「Share Engine」のページです。
 ![アプリアイコン](appIcon.png "hero")
+
+## 概要
+
+**Share Engine**は、シェアハウスでの住人同士の物の貸し借りを円滑に行うためのアプリケーションです。このプラットフォームを通じて、ユーザーは自分の持ち物を簡単に登録し、他の住人と共有することができます。また、必要なアイテムを借りたい時には、アプリを使ってリクエストを送ることができます。**Share Engine**は、共同生活をより便利で快適にすることを目的としています。
+
+このプロジェクトは、React Nativeで作成されたモバイルアプリケーション、PythonとFastAPIを使ったバックエンドAPIサーバー、そしてインフラ構築のためのTerraformスクリプトで構成されています。
+
+## コンポーネント
+
+### Backend (APIサーバー)
+
+- **技術スタック**: Python, FastAPI
+- **機能**: RESTful APIの提供、OpenAPIスキーマの出力
+
+### Frontend (モバイルアプリ)
+
+- **技術スタック**: React Native
+- **プラットフォーム**: Android, iOS
+
+### Infrastructure (インフラストラクチャ)
+
+- **技術スタック**: Terraform
+- **プラットフォーム**: Google Cloud Platform
+
+## セットアップ手順
+
+各コンポーネントのセットアップ手順は、Wikiの[セットアップ手順](https://github.com/EngineMaker/share-engine/wiki/setup)を参照してください。コンポーネントごとのデREADMEにもいろいろ書いています。
+
+## 使用技術
+
+- React Native
+- Python
+- FastAPI
+- Terraform
+- Google Cloud Platform
+
+## ライセンス
+
+[MITライセンス](LICENSE)

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -32,3 +32,4 @@ archive.zip
 
 credential.*
 credentials.*
+out

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,26 @@
 ## How to use?
 
+サーバーを起動
+
 ```
-$ docker build -t hello-world-python .
-$ docker run --rm -p 127.0.0.1:8080:8080 hello-world-python
+docker compose up
 ```
+
+サーバーを起動すると[APIドキュメント](http://localhost:8000/docs)が参照できます。
+
+## APIスキーマ
+
+サーバーを起動して以下を実行するとスキーマファイルがダウンロードできます。  
+ブラウザで http://localhost:8000/openapi.json を開いてもOKです。
+
+```
+curl http://localhost:8000/openapi.json -o openapi.json
+```
+
+サーバーを起動せずに出力することもできます（スクリプトから出力する用）
+
+```
+docker compose run api scripts/generate.sh
+```
+
+`out`フォルダに出力されます

--- a/backend/app/generate-openapi.py
+++ b/backend/app/generate-openapi.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+from main import app
+
+# OpenAPIのスキーマを生成するスクリプト
+# 使い方: python generate-openapi.py
+if __name__ == "__main__":
+    openapi_schema = app.openapi()
+    with open(Path(__file__).resolve().parent / '../out/openapi.json', 'w') as json_file:
+        json.dump(openapi_schema, json_file, indent=2)
+    print("openapi.json has been generated")

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - ./app:/app/app:cached
       - ./scripts:/app/scripts:cached
       - ./credential.json:/app/credential.json:cached
+      - ./out:/app/out
     ports:
       - "8000:80"
     environment:

--- a/backend/scripts/generate.sh
+++ b/backend/scripts/generate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python app/generate-openapi.py


### PR DESCRIPTION
## このPRは何か？

APIサーバのAPIスキーマファイルをコマンドラインから出力できたらいいなと思って作りました。
出力の仕方をメモするついでにREADMEを更新しました。（ChatGPTに書いてもらいました）

コマンドラインからopenapi.jsonを出力できるようになります。
ブラウザからもダウンロードできるみたいですが、スキーマを取得するためだけにAPIサーバを立ち上げるのもアレだなぁ…と思って作りました。（スクリプトからも実行しにくいですし、、、）

以下のコマンドでopenapi.jsonが出力できます。

```
docker compose run api scripts/generate.sh
```

これを使ってadmin画面を作りたい気持ちになってきたので、mainブランチにマージしてもらえたらうれしいです！