### PR TITLE
cloudrunのクレデンシャルの読み込み方法を変更しました。

### DIFF
--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1,13 +1,11 @@
 from google.cloud import storage
-from google.oauth2 import service_account
+import google.auth
 
 # GCSへのアップロード関数
 def upload_to_gcs(bucket_name, source_file_name, destination_blob_name):
     # 認証情報を設定
-    credentials = service_account.Credentials.from_service_account_file(
-        "/app/credential.json"
-    )
-    storage_client = storage.Client(credentials=credentials)
+    credentials, project = google.auth.default()
+    storage_client = storage.Client(project=project, credentials=credentials)
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(destination_blob_name)
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./app:/app/app:cached
       - ./scripts:/app/scripts:cached
-      - ./credential.json:/app/credential.json:cached
+      - ~/.config/gcloud/application_default_credentials.json:/root/.config/gcloud/application_default_credentials.json:cached
     ports:
       - "8000:80"
     environment:

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -33,4 +33,4 @@ override.tf.json
 .terraformrc
 terraform.rc
 
-credentials.json
+credential.*


### PR DESCRIPTION
## 概要

global loadbalancerのバックエンドをGCEからCloud Runに変更。
クレデンシャルファイルの読み込みをservice account keyのcredential.jsonファイルからDAC(default application credentials)に変更。

### ローカル開発の変更

事前準備: 自分から開発者毎にgcpのアカウントを発行するのでそれを使ってgcpにログインする

```
ローカルPCに配布されたgcpアカウントのクレデンシャルを設定する
$ gcloud auth application-default login

バックエンドをで立ち上げる
$ docker-compute up --build
```