### PR TITLE
環境変数「ORIGIN」を追加して欲しい

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - DATABASE_URL=postgresql+asyncpg://enginemaker:password@db:5432/shareengine
       - JWT_SECRET_KEY=CompaniesOverCountries
       - HASH_ALGORITHM=HS256
+      - ORIGIN
     depends_on:
       - db
   db:


### PR DESCRIPTION
## このPRは何か

Webのフロントエンドを個人的に作っているのですが、
APIサーバーのコンテナを起動するときに、ORIGIN環境変数を指定できるとありがたいなぁという気持ちで作りました。
これに設定したオリジン（http://localhost:3000 とか）のページで実行されるJavaScriptからのAPIリクエストを許可するようになるみたいです

何も指定しなければ設定されないので、たぶん本番稼働には影響ないハズ…