### PR TITLE
ローカル開発時の画像のアップロード先をリモートのS3からlocalstackに変更

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,24 +26,16 @@ docker compose run api scripts/generate.sh
 `out`フォルダに出力されます
 
 ## ローカルから画像のアップロードする方法
-awsコマンドを使うので事前にaws cliをインストールしてください。
-https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 
-ストレージに画像アップロードするためにawsクレデンシャルを設定します
+※localstackを使ってs3をローカルpcにシミュレーションしたのでawsクレデンシャル情報は必要なくなりました。
 
-```shell
-aws configure --profile <プロファイル名>
-```
-
-backendディレクトリ直下に.envファイルを作ります
+サーバーを起動
 
 ```shell
-cat << EOF > .env
-AWS_PROFILE_NAME=<プロファイル名>
-AWS_ENDPOINT_URL_S3=<ストレージ画像のエンドポイント>
-IMAGE_HOSTNAME=画像ファイルのホスト名
-EOF
+docker compose up
 ```
 
-その後サーバーを起動してください
+以下の画像アップロードのOpenAPIにアクセスし、画像をPOSTする
+
+http://localhost:8000/docs#/default/create_upload_files_api_v1_uploadfiles__post
 

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 
 AWS_ENDPOINT_URL_S3 = os.environ.get("AWS_ENDPOINT_URL_S3")
 IMAGE_HOSTNAME = os.environ.get("IMAGE_HOSTNAME")
-AWS_PROFILE_NAME = os.environ.get("AWS_PROFILE_NAME")
 
 if not AWS_ENDPOINT_URL_S3:
     logger.error("S3バケットのエンドポイントURLが環境変数に設定されていない")
@@ -15,11 +14,7 @@ if not IMAGE_HOSTNAME:
     logger.error("画像のホスト名が環境変数に設定されていない")
     raise EnvironmentError("IMAGE_HOSTNAME is not found in the environment variables.")
 
-session_params = {}
-if AWS_PROFILE_NAME:
-    session_params['profile_name'] = AWS_PROFILE_NAME
-session = boto3.Session(**session_params)
-s3_client = session.client('s3', endpoint_url=AWS_ENDPOINT_URL_S3)
+s3_client = boto3.client('s3', endpoint_url=AWS_ENDPOINT_URL_S3)
 
 # S3へのアップロード関数
 def upload_to_s3(bucket_name, source_file_name, destination_blob_name):

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     volumes:
       - ./app:/app/app:cached
       - ./scripts:/app/scripts:cached
-      - ~/.aws:/root/.aws
       - ./out:/app/out
     ports:
       - "8000:80"
@@ -13,9 +12,10 @@ services:
       - DATABASE_URL=postgresql+asyncpg://enginemaker:password@db:5432/shareengine
       - JWT_SECRET_KEY=CompaniesOverCountries
       - HASH_ALGORITHM=HS256
-      - AWS_PROFILE_NAME=${AWS_PROFILE_NAME}
-      - AWS_ENDPOINT_URL_S3=${AWS_ENDPOINT_URL_S3}
-      - IMAGE_HOSTNAME=${IMAGE_HOSTNAME}
+      - AWS_ENDPOINT_URL_S3=http://localstack:4566
+      - IMAGE_HOSTNAME=http://localhost:4566/shareengine-storage
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
     depends_on:
       - db
   db:
@@ -28,6 +28,15 @@ services:
       POSTGRES_DB: shareengine
     ports:
       - 5433:5432
+  localstack:
+    image: localstack/localstack:s3-latest
+    ports:
+      - "127.0.0.1:4566:4566"
+    environment:
+      - DEBUG=${DEBUG:-0}
+      - AWS_ENDPOINT_URL_S3=http://localstack:4566
+    volumes:
+      - "./s3/init.py:/etc/localstack/init/ready.d/init-s3.py"
 
 volumes:
   postgres_data:

--- a/backend/s3/init.py
+++ b/backend/s3/init.py
@@ -1,0 +1,12 @@
+import boto3
+import os
+import logging
+logger = logging.getLogger(__name__)
+
+AWS_ENDPOINT_URL_S3 = os.environ.get("AWS_ENDPOINT_URL_S3")
+if not AWS_ENDPOINT_URL_S3:
+    logger.error("S3バケットのエンドポイントURLが環境変数に設定されていない")
+    raise EnvironmentError("AWS_ENDPOINT_URL_S3 is not found in the environment variables.")
+
+s3_client = boto3.client("s3", endpoint_url=AWS_ENDPOINT_URL_S3)
+s3_client.create_bucket(Bucket="shareengine-storage")


### PR DESCRIPTION
## 概要
ローカル開発時の画像のアップロード先をリモートのS3からlocalstackに変更しました。
これによりローカル開発時のawsのクレデンシャルの共有が不要になります。

### やったこと
- docker-composeにlocalstackを追加
- docker composeの初回起動時にlocalstackにs3バケットを作成するスクリプト追加
- 不要なawsプロファイル名を削除