### PR TITLE
S3への接続を、API呼び出しのタイミングまで待って欲しい

### DIFF
--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -18,11 +18,12 @@ if not IMAGE_HOSTNAME:
 session_params = {}
 if AWS_PROFILE_NAME:
     session_params['profile_name'] = AWS_PROFILE_NAME
-session = boto3.Session(**session_params)
-s3_client = session.client('s3', endpoint_url=AWS_ENDPOINT_URL_S3)
 
 # S3へのアップロード関数
 def upload_to_s3(bucket_name, source_file_name, destination_blob_name):
+    session = boto3.Session(**session_params)
+    s3_client = session.client('s3', endpoint_url=AWS_ENDPOINT_URL_S3)
+
     mime_type, _ = mimetypes.guess_type(source_file_name)
     s3_client.upload_file(source_file_name, bucket_name, destination_blob_name, ExtraArgs={'ContentType': mime_type})
     # 公開URLを取得


### PR DESCRIPTION
## このPRは何か

APIスキーマのファイル(openapi.json)を生成する時に、main.pyを参照するのですが、file_services.pyをimportした時点でS3へ接続できないとエラー終了してしまいました。。

スキーマ生成のためにAWSのプロファイルを準備するのも大変だなぁ…と思ったので、APIが呼ばれるまではS3に接続できなくても落ちないようになればいいなあと言う気持ちで作りました。

Share Engine本体には特に必要のない変更だと思うので、何かよくない影響がありそうだったら無視してくださいm(_ _)m